### PR TITLE
Fix OpenAI streaming response handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 out/
+swift/.build/
 forge.config.js
 forge.config.cjs
 .DS_Store

--- a/main.js
+++ b/main.js
@@ -12,6 +12,18 @@ import { defaultSettings } from './default-settings.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+function redactSensitiveData(value) {
+    if (!value || typeof value !== 'object') {
+        return value;
+    }
+
+    const redacted = Array.isArray(value) ? [...value] : { ...value };
+    if (typeof redacted.apiKey === 'string' && redacted.apiKey.length > 0) {
+        redacted.apiKey = '[REDACTED]';
+    }
+    return redacted;
+}
+
 // Auto-updater (production環境でのみ実行)
 if (app.isPackaged) {
     try {
@@ -62,7 +74,7 @@ class GengoElectronMain {
         this.appVersion = await getPackageVersion();
 
         // LLM設定を出力
-        console.log('LLM設定詳細:', this.getLLMConfig());
+        console.log('LLM設定詳細:', redactSensitiveData(this.getLLMConfig()));
 
         // LLMエンジン初期化
         this.llmEngine = this.createLLMEngine();
@@ -2417,7 +2429,7 @@ if ($process) {
                 }
 
                 this.settings = { ...this.settings, ...loadedSettings };
-                console.log('設定を読み込みました:', this.settings);
+                console.log('設定を読み込みました:', redactSensitiveData(this.settings));
             }
         } catch (error) {
             console.error('設定読み込みエラー:', error);

--- a/simple-llm-engine.js
+++ b/simple-llm-engine.js
@@ -427,9 +427,7 @@ export class SimpleLLMEngine {
                         content: prompt
                     }
                 ],
-                stream: false,
-                reasoning: "off",
-                enable_thinking: false
+                stream: false
             };
 
         if (this.provider === 'remote') {
@@ -524,6 +522,44 @@ export class SimpleLLMEngine {
         };
     }
 
+    parseStreamPayloads(streamText) {
+        const payloads = [];
+        const lines = streamText.split(/\r?\n/);
+
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed || trimmed.startsWith(':')) {
+                continue;
+            }
+
+            const payloadText = trimmed.startsWith('data:')
+                ? trimmed.slice(5).trim()
+                : trimmed;
+
+            if (!payloadText || payloadText === '[DONE]') {
+                continue;
+            }
+
+            try {
+                payloads.push(JSON.parse(payloadText));
+            } catch (parseError) {
+                console.warn('ストリーミングチャンクの解析をスキップしました:', payloadText.slice(0, 120));
+            }
+        }
+
+        return payloads;
+    }
+
+    findIncompleteStreamRemainder(streamText) {
+        const lastNewlineIndex = streamText.lastIndexOf('\n');
+        if (lastNewlineIndex === -1) {
+            return streamText;
+        }
+
+        const remainder = streamText.slice(lastNewlineIndex + 1);
+        return remainder.trim() ? remainder : '';
+    }
+
     /**
      * LLM APIを呼び出し（常時ストリーミング）
      */
@@ -553,9 +589,7 @@ export class SimpleLLMEngine {
                         content: prompt
                     }
                 ],
-                stream: true,
-                reasoning: "off",
-                enable_thinking: false
+                stream: true
             };
 
         const useMaxCompletionTokens = this.provider === 'remote' && modelToUse && (
@@ -673,83 +707,46 @@ export class SimpleLLMEngine {
                     }
 
                     buffer += decoder.decode(value, { stream: true });
-                    const events = buffer.split('\n\n');
-                    buffer = events.pop() || '';
+                    const remainder = this.findIncompleteStreamRemainder(buffer);
+                    const parseableText = remainder ? buffer.slice(0, -remainder.length) : buffer;
+                    buffer = remainder;
 
-                    for (const eventText of events) {
-                        const dataLines = eventText
-                            .split('\n')
-                            .map(line => line.trimEnd())
-                            .filter(line => line.startsWith('data:'))
-                            .map(line => line.slice(5).trimStart());
+                    for (const data of this.parseStreamPayloads(parseableText)) {
+                        const parsed = this.extractStreamPayloadText(data);
 
-                        if (dataLines.length === 0) {
-                            continue;
+                        if (parsed.reasoningChunk) {
+                            fullReasoning += parsed.reasoningChunk;
                         }
 
-                        const payloadText = dataLines.join('\n').trim();
-                        if (!payloadText || payloadText === '[DONE]') {
-                            continue;
+                        if (parsed.contentChunk) {
+                            fullText += parsed.contentChunk;
+                        } else if (parsed.absoluteContent && !fullText) {
+                            fullText = parsed.absoluteContent;
                         }
 
-                        try {
-                            const data = JSON.parse(payloadText);
-                            const parsed = this.extractStreamPayloadText(data);
+                        if (parsed.absoluteReasoning && !fullReasoning) {
+                            fullReasoning = parsed.absoluteReasoning;
+                        }
 
-                            if (parsed.reasoningChunk) {
-                                fullReasoning += parsed.reasoningChunk;
-                            }
-
-                            if (parsed.contentChunk) {
-                                fullText += parsed.contentChunk;
-                            } else if (parsed.absoluteContent && !fullText) {
-                                fullText = parsed.absoluteContent;
-                            }
-
-                            if (parsed.absoluteReasoning && !fullReasoning) {
-                                fullReasoning = parsed.absoluteReasoning;
-                            }
-
-                            if (onChunk && (parsed.reasoningChunk || parsed.contentChunk || parsed.absoluteContent)) {
-                                const combinedText = fullReasoning
-                                    ? `<think>\n${fullReasoning}\n</think>\n${fullText}`
-                                    : fullText;
-                                onChunk(parsed.contentChunk || parsed.absoluteContent || '', combinedText);
-                            }
-                        } catch (parseError) {
-                            if (payloadText) {
-                                fullText += payloadText;
-                                if (onChunk) {
-                                    const combinedText = fullReasoning
-                                        ? `<think>\n${fullReasoning}\n</think>\n${fullText}`
-                                        : fullText;
-                                    onChunk(payloadText, combinedText);
-                                }
-                            } else {
-                                console.error('JSON parse error:', parseError, 'Payload:', payloadText);
-                            }
+                        if (onChunk && (parsed.reasoningChunk || parsed.contentChunk || parsed.absoluteContent)) {
+                            const combinedText = fullReasoning
+                                ? `<think>\n${fullReasoning}\n</think>\n${fullText}`
+                                : fullText;
+                            onChunk(parsed.contentChunk || parsed.absoluteContent || '', combinedText);
                         }
                     }
                 }
 
                 const trailing = buffer.trim();
-                if (trailing.startsWith('data:')) {
-                    const payloadText = trailing.slice(5).trimStart();
-                    if (payloadText && payloadText !== '[DONE]') {
-                        try {
-                            const data = JSON.parse(payloadText);
-                            const parsed = this.extractStreamPayloadText(data);
-                            if (parsed.reasoningChunk) {
-                                fullReasoning += parsed.reasoningChunk;
-                            }
-                            if (parsed.contentChunk) {
-                                fullText += parsed.contentChunk;
-                            } else if (parsed.absoluteContent && !fullText) {
-                                fullText = parsed.absoluteContent;
-                            }
-                        } catch {
-                            fullText += payloadText;
-                        }
+                for (const data of this.parseStreamPayloads(trailing)) {
+                    const parsed = this.extractStreamPayloadText(data);
+                    if (parsed.reasoningChunk) {
+                        fullReasoning += parsed.reasoningChunk;
+                    }
+                    if (parsed.contentChunk) {
+                        fullText += parsed.contentChunk;
+                    } else if (parsed.absoluteContent && !fullText) {
+                        fullText = parsed.absoluteContent;
                     }
                 }
             } finally {

--- a/swift/Sources/GenGoSwift/Services/LLMService.swift
+++ b/swift/Sources/GenGoSwift/Services/LLMService.swift
@@ -339,9 +339,6 @@ struct LLMService {
             }
 
             guard let data = trimmed.data(using: .utf8) else {
-                fullText += trimmed
-                let combined = combinedResponseText(reasoning: fullReasoning, content: fullText)
-                await onUpdate(ResponseCleaner.clean(combined, keepThinking: true))
                 return
             }
 
@@ -349,9 +346,6 @@ struct LLMService {
                 let jsonObject = try? JSONSerialization.jsonObject(with: data),
                 let json = jsonObject as? [String: Any]
             else {
-                fullText += trimmed
-                let combined = combinedResponseText(reasoning: fullReasoning, content: fullText)
-                await onUpdate(ResponseCleaner.clean(combined, keepThinking: true))
                 return
             }
 
@@ -377,7 +371,16 @@ struct LLMService {
         for try await line in bytes.lines {
             if line.hasPrefix("data:") {
                 let lineBody = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
-                dataLines.append(lineBody)
+                if lineBody == "[DONE]" || lineBody.trimmingCharacters(in: .whitespaces).hasPrefix("{") {
+                    if !dataLines.isEmpty {
+                        let payload = dataLines.joined(separator: "\n")
+                        dataLines.removeAll(keepingCapacity: true)
+                        await processPayload(payload)
+                    }
+                    await processPayload(lineBody)
+                } else {
+                    dataLines.append(lineBody)
+                }
                 continue
             }
 
@@ -385,6 +388,12 @@ struct LLMService {
                 let payload = dataLines.joined(separator: "\n")
                 dataLines.removeAll(keepingCapacity: true)
                 await processPayload(payload)
+                continue
+            }
+
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("{") || trimmed == "[DONE]" {
+                await processPayload(trimmed)
             }
         }
 
@@ -500,9 +509,7 @@ struct LLMService {
                         "content": prompt
                     ]
                 ],
-                "stream": true,
-                "reasoning": "off",
-                "enable_thinking": false
+                "stream": true
             ]
 
             if usesMaxCompletionTokens(modelIdentifier: modelIdentifier) {
@@ -747,7 +754,55 @@ struct LLMService {
             }
         }
 
+        if trimmed.contains("\"chat.completion.chunk\"") || trimmed.split(whereSeparator: \.isNewline).contains(where: { String($0).trimmingCharacters(in: .whitespaces).hasPrefix("{") }) {
+            let streamText = extractResponseTextFromBufferedStreamLines(trimmed, provider: provider)
+            if !streamText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return streamText
+            }
+        }
+
         return trimmed
+    }
+
+    private func extractResponseTextFromBufferedStreamLines(_ text: String, provider: LLMProvider) -> String {
+        var fullText = ""
+        var fullReasoning = ""
+
+        for rawLine in text.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty, line != "[DONE]" else {
+                continue
+            }
+
+            let payloadText = line.hasPrefix("data:")
+                ? String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                : line
+
+            guard
+                !payloadText.isEmpty,
+                payloadText != "[DONE]",
+                let payloadData = payloadText.data(using: .utf8),
+                let jsonObject = try? JSONSerialization.jsonObject(with: payloadData),
+                let json = jsonObject as? [String: Any]
+            else {
+                continue
+            }
+
+            let chunk = extractStreamChunk(from: json, provider: provider)
+            if !chunk.reasoningChunk.isEmpty {
+                fullReasoning += chunk.reasoningChunk
+            } else if !chunk.absoluteReasoning.isEmpty, fullReasoning.isEmpty {
+                fullReasoning = chunk.absoluteReasoning
+            }
+
+            if !chunk.contentChunk.isEmpty {
+                fullText += chunk.contentChunk
+            } else if !chunk.absoluteContent.isEmpty, fullText.isEmpty {
+                fullText = chunk.absoluteContent
+            }
+        }
+
+        return combinedResponseText(reasoning: fullReasoning, content: fullText)
     }
 
     private func extractResponseTextFromBufferedEventStream(_ text: String, provider: LLMProvider) -> String {


### PR DESCRIPTION
## Summary
- Remove unsupported OpenAI-compatible request parameters from remote chat completion requests
- Parse OpenAI streaming chunks instead of displaying raw JSON
- Redact API keys from startup logs
- Ignore Swift build artifacts

## Verification
- `node --check main.js`
- `node --check simple-llm-engine.js`
- `swift build`